### PR TITLE
Jetbrain Webstorm 메타파일 gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# idea
+.idea/


### PR DESCRIPTION
# Summary
Jetbrain의 Webstorm IDE에 의해 자동으로 생성되는 `.idea/` 디렉토리 파일들이 저장소에 업로드되지 않도록 `.gitignore`에 해당 디렉토리를 추가하였습니다.

## Context
```
# idea
.idea/
```