### PR TITLE
refactor: 커스텀 설정을 위한 env 프로퍼티 분리

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-TIMEZONE='Asia/Seoul'
+NEXT_PUBLIC_TIMEZONE='Asia/Seoul'
 
 # Metadata
 METADATA_TITLE='ksone.blog'
@@ -11,7 +11,7 @@ METADATA_ICON='/ms-icon-310x310.png'
 
 # Blog configuration
 TITLE='ksone.blog'
-AUTHOR='강상원'
+NEXT_PUBLIC_AUTHOR='강상원'
 GITHUB_LINK_ENABLED=true
 LINKEDIN_LINK_ENABLED=true
 
@@ -24,11 +24,11 @@ GITHUB_REPO='obsidian-note'
 LINKEDIN_PROFILE='%EC%83%81%EC%9B%90-%EA%B0%95-7b6007275'
 
 # Giscus (Post reaction)
-GISCUS_OWNER='ksone02'
-GISCUS_REPO='blog-reaction'
-GISCUS_REPO_ID='R_kgDONsTkyw'
-GISCUS_CATEGORY='Announcements'
-GISCUS_CATEGORY_ID='DIC_kwDONsTky84CmJb6'
+NEXT_PUBLIC_GISCUS_OWNER='ksone02'
+NEXT_PUBLIC_GISCUS_REPO='blog-reaction'
+NEXT_PUBLIC_GISCUS_REPO_ID='R_kgDONsTkyw'
+NEXT_PUBLIC_GISCUS_CATEGORY='Announcements'
+NEXT_PUBLIC_GISCUS_CATEGORY_ID='DIC_kwDONsTky84CmJb6'
 
 # Supabase
 NEXT_PUBLIC_SUPABASE_URL=''

--- a/.env
+++ b/.env
@@ -1,0 +1,35 @@
+TIMEZONE='Asia/Seoul'
+
+# Metadata
+METADATA_TITLE='ksone.blog'
+METADATA_DESC='강상원의 블로그'
+METADATA_KEYWORDS='["ksone", "blog", "frontend", "developer", "javascript", "typescript", "react"]'
+METADATA_OPEN_GRAPH_TITLE='ksone.blog'
+METADATA_OPEN_GRAPH_DESC='강상원의 블로그'
+METADATA_OPEN_GRAPH_IMAGES='["/og_image.png"]'
+METADATA_ICON='/ms-icon-310x310.png'
+
+# Blog configuration
+TITLE='ksone.blog'
+AUTHOR='강상원'
+GITHUB_LINK_ENABLED=true
+LINKEDIN_LINK_ENABLED=true
+
+# Github
+GITHUB_TOKEN=''
+GITHUB_OWNER='ksone02'
+GITHUB_REPO='obsidian-note'
+
+# Linkedin
+LINKEDIN_PROFILE='%EC%83%81%EC%9B%90-%EA%B0%95-7b6007275'
+
+# Giscus (Post reaction)
+GISCUS_OWNER='ksone02'
+GISCUS_REPO='blog-reaction'
+GISCUS_REPO_ID='R_kgDONsTkyw'
+GISCUS_CATEGORY='Announcements'
+GISCUS_CATEGORY_ID='DIC_kwDONsTky84CmJb6'
+
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=''
+NEXT_PUBLIC_SUPABASE_ANON_KEY=''

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env.*
 
 # vercel
 .vercel

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,91 +58,100 @@ const pretendard = localFont({
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
-    title: 'ksone.blog',
-    description: '강상원의 블로그',
-    keywords: ['ksone', 'blog', 'frontend', 'developer', 'javascript', 'typescript', 'react'],
+    title: process.env.METADATA_TITLE,
+    description: process.env.METADATA_DESC,
+    keywords: JSON.parse(process.env.METADATA_KEYWORDS || '[]'),
     openGraph: {
-      title: 'ksone.blog',
-      description: '강상원의 블로그',
-      images: ['/og_image.png'],
+      title: process.env.METADATA_OPEN_GRAPH_TITLE,
+      description: process.env.METADATA_OPEN_GRAPH_DESC,
+      images: JSON.parse(process.env.METADATA_OPEN_GRAPH_IMAGES || '[]'),
     },
     icons: {
-      icon: '/ms-icon-310x310.png',
+      icon: process.env.METADATA_ICON,
     },
   };
 }
 
-const RootLayout = ({ children }: { children: React.ReactNode }) => (
-  <html lang="ko" className={`${pretendard.className} ${firaMono.className} ${inter.className}`}>
-    <Script
-      strategy="afterInteractive"
-      src="https://www.googletagmanager.com/gtag/js?id=G-RWB7RJ9M52"
-    />
-    <Script
-      id="gtag-init"
-      strategy="afterInteractive"
-      dangerouslySetInnerHTML={{
-        __html: `
+const RootLayout = ({ children }: { children: React.ReactNode }) => {
+  const isGithubIconEnabled = process.env.GITHUB_LINK_ENABLED === 'true';
+  const isLinkedInIconEnabled = process.env.LINKEDIN_LINK_ENABLED === 'true';
+
+  return (
+    <html lang="ko" className={`${pretendard.className} ${firaMono.className} ${inter.className}`}>
+      <Script
+        strategy="afterInteractive"
+        src="https://www.googletagmanager.com/gtag/js?id=G-RWB7RJ9M52"
+      />
+      <Script
+        id="gtag-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', 'G-RWB7RJ9M52');
           `,
-      }}
-    />
+        }}
+      />
 
-    <body>
-      <header className="header">
-        <nav className="nav">
-          <div>
-            <a href="/">
-              <h1 className="logo">ksone.blog</h1>
-            </a>
-          </div>
-          <div style={{ display: 'flex', gap: '12px' }}>
-            <a
-              href="https://github.com/ksone02"
-              target="_blank"
-              rel="noopener noreferrer"
-              type="button"
-              style={{
-                color: '#333',
-                padding: '8px 8px',
-                borderRadius: '6px',
-                transition: 'background 0.2s ease',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '6px',
-              }}
-            >
-              <svg height="24" width="24" viewBox="0 0 16 16" fill="currentColor">
-                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-              </svg>
-            </a>
-            <a
-              href="https://www.linkedin.com/in/%EC%83%81%EC%9B%90-%EA%B0%95-7b6007275/"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                color: '#333',
-                padding: '8px 8px',
-                borderRadius: '6px',
-                transition: 'background 0.2s ease',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '6px',
-              }}
-            >
-              <svg height="24" width="24" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M20.5 2h-17A1.5 1.5 0 002 3.5v17A1.5 1.5 0 003.5 22h17a1.5 1.5 0 001.5-1.5v-17A1.5 1.5 0 0020.5 2zM8 19H5v-9h3zM6.5 8.25A1.75 1.75 0 118.3 6.5a1.78 1.78 0 01-1.8 1.75zM19 19h-3v-4.74c0-1.42-.6-1.93-1.38-1.93A1.74 1.74 0 0013 14.19a.66.66 0 000 .14V19h-3v-9h2.9v1.3a3.11 3.11 0 012.7-1.4c1.55 0 3.36.86 3.36 3.66z" />
-              </svg>
-            </a>
-          </div>
-        </nav>
-      </header>
-      <main className="main">{children}</main>
-    </body>
-  </html>
-);
+      <body>
+        <header className="header">
+          <nav className="nav">
+            <div>
+              <a href="/">
+                <h1 className="logo">{process.env.TITLE}</h1>
+              </a>
+            </div>
+            <div style={{ display: 'flex', gap: '12px' }}>
+              {isGithubIconEnabled && (
+                <a
+                  href={`https://github.com/${process.env.GITHUB_OWNER}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  type="button"
+                  style={{
+                    color: '#333',
+                    padding: '8px 8px',
+                    borderRadius: '6px',
+                    transition: 'background 0.2s ease',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  <svg height="24" width="24" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                  </svg>
+                </a>
+              )}
+              {isLinkedInIconEnabled && (
+                <a
+                  href={`https://www.linkedin.com/in/${encodeURIComponent(process.env.LINKEDIN_PROFILE ?? '')}/`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    color: '#333',
+                    padding: '8px 8px',
+                    borderRadius: '6px',
+                    transition: 'background 0.2s ease',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                  }}
+                >
+                  <svg height="24" width="24" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M20.5 2h-17A1.5 1.5 0 002 3.5v17A1.5 1.5 0 003.5 22h17a1.5 1.5 0 001.5-1.5v-17A1.5 1.5 0 0020.5 2zM8 19H5v-9h3zM6.5 8.25A1.75 1.75 0 118.3 6.5a1.78 1.78 0 01-1.8 1.75zM19 19h-3v-4.74c0-1.42-.6-1.93-1.38-1.93A1.74 1.74 0 0013 14.19a.66.66 0 000 .14V19h-3v-9h2.9v1.3a3.11 3.11 0 012.7-1.4c1.55 0 3.36.86 3.36 3.66z" />
+                  </svg>
+                </a>
+              )}
+            </div>
+          </nav>
+        </header>
+        <main className="main">{children}</main>
+      </body>
+    </html>
+  );
+};
 
 export default RootLayout;

--- a/src/components/post/PostDetail.tsx
+++ b/src/components/post/PostDetail.tsx
@@ -109,7 +109,7 @@ const PostDetail = ({ post }: PostDetailProps) => {
             </div>
           )}
           <h1 className={styles.title}>{post.title}</h1>
-          <span className={styles.author}>from. {process.env.AUTHOR}</span>
+          <span className={styles.author}>from. {process.env.NEXT_PUBLIC_AUTHOR}</span>
           <div className={styles.meta}>
             <span className={styles.category}>{post.category}</span>
             <span className={styles.date}>{format(new Date(post.date), 'yyyy년 MM월 dd일')}</span>
@@ -198,10 +198,10 @@ const PostDetail = ({ post }: PostDetailProps) => {
         </div>
         <Giscus
           id="comments"
-          repo={`${process.env.GISCUS_OWNER}/${process.env.GISCUS_REPO}`}
-          repoId={`${process.env.GISCUS_REPO_ID}`}
-          category={`${process.env.GISCUS_CATEGORY}`}
-          categoryId={`${process.env.GISCUS_CATEGORY_ID}`}
+          repo={`${process.env.NEXT_PUBLIC_GISCUS_OWNER}/${process.env.NEXT_PUBLIC_GISCUS_REPO}`}
+          repoId={`${process.env.NEXT_PUBLIC_GISCUS_REPO_ID}`}
+          category={`${process.env.NEXT_PUBLIC_GISCUS_CATEGORY}`}
+          categoryId={`${process.env.NEXT_PUBLIC_GISCUS_CATEGORY_ID}`}
           mapping="pathname"
           term="Welcome to @giscus/react component!"
           reactionsEnabled="1"

--- a/src/components/post/PostDetail.tsx
+++ b/src/components/post/PostDetail.tsx
@@ -109,7 +109,7 @@ const PostDetail = ({ post }: PostDetailProps) => {
             </div>
           )}
           <h1 className={styles.title}>{post.title}</h1>
-          <span className={styles.author}>from. 강상원</span>
+          <span className={styles.author}>from. {process.env.AUTHOR}</span>
           <div className={styles.meta}>
             <span className={styles.category}>{post.category}</span>
             <span className={styles.date}>{format(new Date(post.date), 'yyyy년 MM월 dd일')}</span>
@@ -198,10 +198,10 @@ const PostDetail = ({ post }: PostDetailProps) => {
         </div>
         <Giscus
           id="comments"
-          repo="ksone02/blog-reaction"
-          repoId="R_kgDONsTkyw"
-          category="Announcements"
-          categoryId="DIC_kwDONsTky84CmJb6"
+          repo={`${process.env.GISCUS_OWNER}/${process.env.GISCUS_REPO}`}
+          repoId={`${process.env.GISCUS_REPO_ID}`}
+          category={`${process.env.GISCUS_CATEGORY}`}
+          categoryId={`${process.env.GISCUS_CATEGORY_ID}`}
           mapping="pathname"
           term="Welcome to @giscus/react component!"
           reactionsEnabled="1"

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -5,12 +5,20 @@ import matter from 'gray-matter';
 
 import type { Post } from '@/types/github';
 
+const GH_TOKEN = process.env.GITHUB_TOKEN;
+const GH_OWNER = process.env.GITHUB_OWNER;
+const GH_REPO = process.env.GITHUB_REPO;
+
+if (!GH_TOKEN || !GH_TOKEN.trim() || !GH_OWNER || !GH_OWNER.trim() || !GH_REPO || !GH_REPO.trim()) {
+  throw new Error('Required GitHub Environments. (TOKEN | OWNER_NAME | REPO_NAME)');
+}
+
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
 });
 
-const OWNER = process.env.GITHUB_OWNER || 'ksone02';
-const REPO = process.env.GITHUB_REPO || 'obsidian-note';
+const OWNER = process.env.GITHUB_OWNER || '';
+const REPO = process.env.GITHUB_REPO || '';
 
 export async function getAllPosts(): Promise<Post[]> {
   try {
@@ -86,7 +94,11 @@ async function recursivelyFetchPosts(path: string): Promise<Post[]> {
       const utcDate =
         commits.data[0]?.commit.author?.date || frontMatter.date || new Date().toISOString();
 
-      const fileDate = formatInTimeZone(new Date(utcDate), 'Asia/Seoul', 'yyyy-MM-dd');
+      const fileDate = formatInTimeZone(
+        new Date(utcDate),
+        process.env.TIMEZONE || 'Asia/Seoul',
+        'yyyy-MM-dd',
+      );
 
       return [
         {
@@ -108,6 +120,7 @@ async function recursivelyFetchPosts(path: string): Promise<Post[]> {
   const postsArrays = await Promise.all(data.map(processItem));
   return postsArrays.flat();
 }
+
 async function getFileContent(path: string, isImage: boolean = false): Promise<string> {
   const { data } = await octokit.repos.getContent({
     owner: OWNER,

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -96,7 +96,7 @@ async function recursivelyFetchPosts(path: string): Promise<Post[]> {
 
       const fileDate = formatInTimeZone(
         new Date(utcDate),
-        process.env.TIMEZONE || 'Asia/Seoul',
+        process.env.NEXT_PUBLIC_TIMEZONE || 'Asia/Seoul',
         'yyyy-MM-dd',
       );
 


### PR DESCRIPTION
# Summary
블로그 타이틀, 작성자, Github 토큰 등 여러 env 변수들을 커스텀하고 관리하기 용이하도록 .env 파일을 생성하여 분리하였으며,
각 유저별 env가 업로드되지 않도록 하기 위해 `.gitignore`의 `.env`를 `.env.*`로 수정하였습니다.

# Context
`.env` 파일을 생성하여 Timezone, Metadata, Blog Configuration, Github, Linkedin, Giscus, Supabase 설정을 할 수 있도록 하였고,
디폴트로 우선 상원님의 설정값로 넣어두었습니다.

추후 필요 시 상원님의 설정값도 분리하고 `.env` 파일에는 `your-name.blog`나 `''` 로 디폴트값을 수정하는건 어떤지 의견드립니다.

# Requirement
`METADATA_OPEN_GRAPH_IMAGES` 값 중 `/og_image.png`가 ksone.blog 라는 텍스트 이미지이던데, 커스텀이 가능할까요? Metadata라 보여지는 이미지는 아닌것 같아서 우선 저도 해당 이미지로 넣어두었습니다.
